### PR TITLE
Revert change to start_key and end_key defaults

### DIFF
--- a/include/couch_mrview.hrl
+++ b/include/couch_mrview.hrl
@@ -60,9 +60,9 @@
     preflight_fun,
 
     start_key,
-    start_key_docid = ?MIN_STR,
+    start_key_docid,
     end_key,
-    end_key_docid = ?MAX_STR,
+    end_key_docid,
     keys,
 
     direction = fwd,


### PR DESCRIPTION
This partially reverts commit d85ca9e12f7f689aa76aeef83f7d725a729688fd

BugzID: 44229
