### PR TITLE
Fix bug in view states convertion during migration

### DIFF
--- a/src/couch_mrview_util.erl
+++ b/src/couch_mrview_util.erl
@@ -212,8 +212,11 @@ init_state(Db, Fd, State, #index_header{
     purge_seq=PurgeSeq,
     id_btree_state=IdBtreeState,
     view_states=ViewStates}) ->
-    NewViewStates = lists:map(fun({Pos, {Cnts, UsrReds, _DtSize}, Size}) ->
-        {{Pos, {Cnts, UsrReds}, Size}, nil, nil, Seq, PurgeSeq}
+    NewViewStates = lists:map(fun
+        (nil) ->
+            {nil, nil, nil, 0, 0};
+        ({Pos, {Cnts, UsrReds, _DtSize}, Size}) ->
+            {{Pos, {Cnts, UsrReds}, Size}, nil, nil, Seq, PurgeSeq}
     end, ViewStates),
     init_state(Db, Fd, State, #mrheader{
         seq=Seq,


### PR DESCRIPTION
This patch takes into account possible uninitialized view states during an index migration.

BugzID: 57882
